### PR TITLE
flatten docs, move category to component definition

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { HashRouter as Router, Route, NavLink } from 'react-router-dom';
-import docs from './docs/docs';
+import {basicShapes, curves} from './docs/docs';
 import Introduction from './components/Introduction';
 import Nav from './components/Nav';
 import { PathIntro } from './components/PathIntro';
@@ -13,8 +13,8 @@ import { ToComponent } from './components/ToComponent';
 import './App.css';
 
 const App = () => {
-  const basicShapes = Object.keys(docs.basicShapes);
-  const curves = Object.keys(docs.curves);
+  const shapesDemos = Object.keys(basicShapes);
+  const curveDemos = Object.keys(curves);
 
   return (
     <Router basename='/'>
@@ -39,7 +39,7 @@ const App = () => {
           <Route exact path={`/markers`} render={() => <MarkerDemo />} />
 
           <div className='basic-shapes'>
-            {basicShapes.map((s, i) => (
+            {shapesDemos.map((s, i) => (
               <Route
                 key={s}
                 exact
@@ -47,7 +47,7 @@ const App = () => {
                 render={() => <BasicShapeDemo shape={s} />}
               />
             ))}
-            {curves.map((c, i) => (
+            {curveDemos.map((c, i) => (
               <Route
                 key={c}
                 exact

--- a/example/src/components/BasicShapeDemo.js
+++ b/example/src/components/BasicShapeDemo.js
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import * as Shapes from 'react-svg-path';
 import { Knobs } from './Knobs';
-import docs from '../docs/docs';
+import {basicShapes as docs} from '../docs/docs';
 import demoDocs from '../docs/demos';
 
 export const BasicShapeDemo = ({ shape }) => {
-  const { Component, props, description } = docs.basicShapes[shape];
+  const { Component, props, description } = docs[shape];
   const demos = demoDocs.basicShapes[shape];
   const initialState = demos.map((d, i) => {
     return Object.keys(d)

--- a/example/src/components/CurveDemo.js
+++ b/example/src/components/CurveDemo.js
@@ -4,7 +4,7 @@ import docs from '../docs/docs';
 import demoDocs from '../docs/demos';
 
 export const CurveDemo = ({ curve }) => {
-  const { Component, props, description } = docs.curves[curve];
+  const { Component, props, description } = docs[curve];
   const demos = demoDocs.curves[curve];
   const C = Shapes[Component];
   const Svg = Shapes.Svg;

--- a/example/src/components/Nav.js
+++ b/example/src/components/Nav.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import docs from '../docs/docs';
+import {basicShapes, curves} from '../docs/docs';
 
 const Nav = () => {
   return (
@@ -26,15 +26,15 @@ const Nav = () => {
       <div className='item'>
         <div className='active  header'>Shapes</div>
         <div className='menu'>
-          {Object.keys(docs.basicShapes)
+          {Object.keys(basicShapes)
             .sort()
             .map((c, index) => (
               <NavLink
                 key={c}
                 className='item'
-                to={`/${docs.basicShapes[c].Component.toLowerCase()}`}
+                to={`/${basicShapes[c].Component.toLowerCase()}`}
               >
-                {docs.basicShapes[c].Component}
+                {basicShapes[c].Component}
               </NavLink>
             ))}
         </div>
@@ -42,15 +42,15 @@ const Nav = () => {
       <div className='item'>
         <div className='active  header'>Curves</div>
         <div className='menu'>
-          {Object.keys(docs.curves)
+          {Object.keys(curves)
             .sort()
             .map((c, index) => (
               <NavLink
                 key={c}
                 className='item'
-                to={`/${docs.curves[c].Component.toLowerCase()}`}
+                to={`/${curves[c].Component.toLowerCase()}`}
               >
-                {docs.curves[c].Component}
+                {curves[c].Component}
               </NavLink>
             ))}
         </div>

--- a/example/src/docs/docs.js
+++ b/example/src/docs/docs.js
@@ -23,558 +23,585 @@ const centeredShapeNestingProps = {
 };
 
 const docs = {
-  basicShapes: {
-    circle: {
-      Component: 'Circle',
-      command: 'circle',
-      args: ['size', 'cx', 'cy'],
-      description:
-        'Circle is drawn from center points (cx & cy). The cursor is then moved to the center points.',
-      props: {
-        size: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
+  circle: {
+    category: 'basicShapes',
+    Component: 'Circle',
+    command: 'circle',
+    args: ['size', 'cx', 'cy'],
+    description:
+      'Circle is drawn from center points (cx & cy). The cursor is then moved to the center points.',
+    props: {
+      size: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       },
-      nestingProps: centeredShapeNestingProps
-    },
-    ellipse: {
-      Component: 'Ellipse',
-      command: 'ellipse',
-      args: ['width', 'height', 'cx', 'cy'],
-      description:
-        'Ellipse is drawn from center point (cx & cy). The cursor is then moved to the center point.',
-      props: {
-        width: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        height: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       },
-      nestingProps: centeredShapeNestingProps
-    },
-    polygon: {
-      Component: 'Polygon',
-      command: 'polygon',
-      args: ['points'],
-      description:
-        'Polygon accepts an array of [x, y] coordinates and then draws lines connecting those points.  The path will start from the first point and end on the first point - closing the shape.',
-      props: {
-        points: {
-          type: 'point-array',
-          isRequired: true,
-          validator: pointArrayValidator
-        }
-      },
-      nestingProps: ({ points }) => {
-        const [sx, sy] = points[0];
-        const [ex, ey] = points[points.length - 1];
-        return { ex: sx, ey: sy, sx: ex, sy: ey };
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       }
     },
-    polygram: {
-      Component: 'Polygram',
-      command: 'polygram',
-      args: ['size', 'points', 'cx', 'cy', 'vertexSkip'],
-      description:
-        'Polygram is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.  Skipping a vertex is what makes a polygram appear as intersecting lines, a vertexSkip of 1 will result in a regular polygon.',
-      props: {
-        size: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        points: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        vertexSkip: {
-          type: 'number',
-          validator: commonNumberValidator,
-          default: 2
-        }
+    nestingProps: centeredShapeNestingProps
+  },
+  ellipse: {
+    category: 'basicShapes',
+    Component: 'Ellipse',
+    command: 'ellipse',
+    args: ['width', 'height', 'cx', 'cy'],
+    description:
+      'Ellipse is drawn from center point (cx & cy). The cursor is then moved to the center point.',
+    props: {
+      width: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       },
-      nestingProps: centeredShapeNestingProps
-    },
-    polyline: {
-      Component: 'Polyline',
-      command: 'polyline',
-      args: ['points', 'relative'],
-      description:
-        'Polyline accepts an array of [x, y] coordinates and then draws lines connecting those points.  The path will start from the first point and end on the last.  points can be absolute or relative.',
-      props: {
-        points: {
-          type: 'point-array',
-          isRequired: true,
-          validator: pointArrayValidator
-        },
-        relative: { type: 'boolean' }
+      height: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       },
-      nestingProps: ({ points }) => {
-        const [sx, sy] = points[0];
-        const [ex, ey] = points[points.length - 1];
-        return { ex: sx, ey: sy, sx: ex, sy: ey };
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       }
     },
-    line: {
-      Component: 'Line',
-      command: 'lineTo',
-      description:
-        'Line is drawn from starting points (sx & sy) to ending points (ex & ey). sx (starting x) & sy (starting y) will always be absolutely positioned, however with relative=true the ex and ey points can relative to sx & sy.',
-      props: {
-        sx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        sy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ex: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ey: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        relative: { type: 'boolean' }
+    nestingProps: centeredShapeNestingProps
+  },
+  polygon: {
+    category: 'basicShapes',
+    Component: 'Polygon',
+    command: 'polygon',
+    args: ['points'],
+    description:
+      'Polygon accepts an array of [x, y] coordinates and then draws lines connecting those points.  The path will start from the first point and end on the first point - closing the shape.',
+    props: {
+      points: {
+        type: 'point-array',
+        isRequired: true,
+        validator: pointArrayValidator
       }
     },
-    radialLines: {
-      Component: 'RadialLines',
-      command: 'radialLines',
-      args: ['outerSize', 'innerSize', 'points', 'cx', 'cy'],
-      description:
-        'RadialLines is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.',
-      props: {
-        outerSize: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        innerSize: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        points: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
-    },
-    rect: {
-      Component: 'Rect',
-      command: 'rect',
-      args: ['width', 'height', 'cx', 'cy'],
-      description:
-        'Rect is drawn from center point (cx & cy). The cursor is then moved to the center point.',
-      props: {
-        width: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        height: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
-    },
-    regPolygon: {
-      Component: 'RegPolygon',
-      command: 'regPolygon',
-      args: ['size', 'sides', 'cx', 'cy'],
-      description:
-        'RegPolygon is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.',
-      props: {
-        size: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        sides: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
-    },
-    sector: {
-      Component: 'Sector',
-      command: 'sector',
-      args: ['cx', 'cy', 'size', 'startAngle', 'endAngle'],
-      description:
-        'Sector is drawn from center point (cx & cy). The cursor is then moved to the center point.',
-      props: {
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        size: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        startAngle: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        endAngle: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
-    },
-    segment: {
-      Component: 'Segment',
-      command: 'segment',
-      args: ['cx', 'cy', 'size', 'startAngle', 'endAngle'],
-      description:
-        'Segment is drawn from center point (cx & cy). The cursor is then moved to the center point.',
-      props: {
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        size: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        startAngle: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        endAngle: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
-    },
-    square: {
-      Component: 'Square',
-      command: 'square',
-      args: ['size', 'cx', 'cy'],
-      description:
-        'Square is drawn from center point (cx & cy). The cursor is then moved to the center point.',
-      props: {
-        size: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
-    },
-    star: {
-      Component: 'Star',
-      command: 'star',
-      args: ['outerSize', 'innerSize', 'points', 'cx', 'cy'],
-      description:
-        'Star is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.',
-      props: {
-        outerSize: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        innerSize: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        points: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
-    },
-    triangle: {
-      Component: 'Triangle',
-      command: 'triangle',
-      args: ['size', 'cx', 'cy'],
-      description:
-        'Triangle draws an equilateral triangle from center point (cx & cy). The cursor is then moved to the center point.',
-      props: {
-        size: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
+    nestingProps: ({ points }) => {
+      const [sx, sy] = points[0];
+      const [ex, ey] = points[points.length - 1];
+      return { ex: sx, ey: sy, sx: ex, sy: ey };
     }
   },
-  curves: {
-    arc: {
-      Component: 'Arc',
-      command: 'arc',
-      args: ['rx', 'ry', 'rotation', 'arc', 'sweep', 'ex', 'ey'],
-      description: 'Arc is drawn...',
-      props: {
-        sx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        sy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        rx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ry: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        rotation: {
-          type: 'number',
-          validator: commonNumberValidator
-        },
-        arc: {
-          type: 'number',
-          validator: commonNumberValidator
-        },
-        sweep: {
-          type: 'number',
-          validator: commonNumberValidator
-        },
-        ex: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ey: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
+  polygram: {
+    category: 'basicShapes',
+    Component: 'Polygram',
+    command: 'polygram',
+    args: ['size', 'points', 'cx', 'cy', 'vertexSkip'],
+    description:
+      'Polygram is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.  Skipping a vertex is what makes a polygram appear as intersecting lines, a vertexSkip of 1 will result in a regular polygon.',
+    props: {
+      size: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      points: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      vertexSkip: {
+        type: 'number',
+        validator: commonNumberValidator,
+        default: 2
       }
     },
-    cubic: {
-      Component: 'Cubic',
-      command: 'cCurve',
-      args: ['cx1', 'cy1', 'cx2', 'cy2', 'ex', 'ey'],
-      description: 'Cubic is drawn...',
-      props: {
-        sx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        sy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx1: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy1: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx2: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy2: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ex: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ey: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        S: { type: 'point-array' },
-        s: { type: 'point-array' }
+    nestingProps: centeredShapeNestingProps
+  },
+  polyline: {
+    category: 'basicShapes',
+    Component: 'Polyline',
+    command: 'polyline',
+    args: ['points', 'relative'],
+    description:
+      'Polyline accepts an array of [x, y] coordinates and then draws lines connecting those points.  The path will start from the first point and end on the last.  points can be absolute or relative.',
+    props: {
+      points: {
+        type: 'point-array',
+        isRequired: true,
+        validator: pointArrayValidator
+      },
+      relative: { type: 'boolean' }
+    },
+    nestingProps: ({ points }) => {
+      const [sx, sy] = points[0];
+      const [ex, ey] = points[points.length - 1];
+      return { ex: sx, ey: sy, sx: ex, sy: ey };
+    }
+  },
+  line: {
+    category: 'basicShapes',
+    Component: 'Line',
+    command: 'lineTo',
+    args: ['x', 'y'],
+    description:
+      'Line is drawn from starting points (sx & sy) to ending points (ex & ey). sx (starting x) & sy (starting y) will always be absolutely positioned, however with relative=true the ex and ey points can relative to sx & sy.',
+    props: {
+      sx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      sy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ex: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ey: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      relative: { type: 'boolean' }
+    }
+  },
+  radialLines: {
+    category: 'basicShapes',
+    Component: 'RadialLines',
+    command: 'radialLines',
+    args: ['outerSize', 'innerSize', 'points', 'cx', 'cy'],
+    description:
+      'RadialLines is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.',
+    props: {
+      outerSize: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      innerSize: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      points: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       }
     },
-    quad: {
-      Component: 'Quad',
-      command: 'qCurve',
-      args: ['cx', 'cy', 'ex', 'ey'],
-      description: 'Quad is drawn...',
-      props: {
-        sx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        sy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ex: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ey: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        T: { type: 'point-array' },
-        t: { type: 'point-array' }
+    nestingProps: centeredShapeNestingProps
+  },
+  rect: {
+    category: 'basicShapes',
+    Component: 'Rect',
+    command: 'rect',
+    args: ['width', 'height', 'cx', 'cy'],
+    description:
+      'Rect is drawn from center point (cx & cy). The cursor is then moved to the center point.',
+    props: {
+      width: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      height: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       }
+    },
+    nestingProps: centeredShapeNestingProps
+  },
+  regPolygon: {
+    category: 'basicShapes',
+    Component: 'RegPolygon',
+    command: 'regPolygon',
+    args: ['size', 'sides', 'cx', 'cy'],
+    description:
+      'RegPolygon is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.',
+    props: {
+      size: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      sides: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      }
+    },
+    nestingProps: centeredShapeNestingProps
+  },
+  sector: {
+    category: 'basicShapes',
+    Component: 'Sector',
+    command: 'sector',
+    args: ['cx', 'cy', 'size', 'startAngle', 'endAngle'],
+    description:
+      'Sector is drawn from center point (cx & cy). The cursor is then moved to the center point.',
+    props: {
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      size: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      startAngle: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      endAngle: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      }
+    },
+    nestingProps: centeredShapeNestingProps
+  },
+  segment: {
+    category: 'basicShapes',
+    Component: 'Segment',
+    command: 'segment',
+    args: ['cx', 'cy', 'size', 'startAngle', 'endAngle'],
+    description:
+      'Segment is drawn from center point (cx & cy). The cursor is then moved to the center point.',
+    props: {
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      size: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      startAngle: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      endAngle: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      }
+    },
+    nestingProps: centeredShapeNestingProps
+  },
+  square: {
+    category: 'basicShapes',
+    Component: 'Square',
+    command: 'square',
+    args: ['size', 'cx', 'cy'],
+    description:
+      'Square is drawn from center point (cx & cy). The cursor is then moved to the center point.',
+    props: {
+      size: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      }
+    },
+    nestingProps: centeredShapeNestingProps
+  },
+  star: {
+    category: 'basicShapes',
+    Component: 'Star',
+    command: 'star',
+    args: ['outerSize', 'innerSize', 'points', 'cx', 'cy'],
+    description:
+      'Star is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.',
+    props: {
+      outerSize: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      innerSize: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      points: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      }
+    },
+    nestingProps: centeredShapeNestingProps
+  },
+  triangle: {
+    category: 'basicShapes',
+    Component: 'Triangle',
+    command: 'triangle',
+    args: ['size', 'cx', 'cy'],
+    description:
+      'Triangle draws an equilateral triangle from center point (cx & cy). The cursor is then moved to the center point.',
+    props: {
+      size: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      }
+    },
+    nestingProps: centeredShapeNestingProps
+  },
+  arc: {
+    category: 'curves',
+    Component: 'Arc',
+    command: 'arc',
+    args: ['rx', 'ry', 'rotation', 'arc', 'sweep', 'ex', 'ey'],
+    description: 'Arc is drawn...',
+    props: {
+      sx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      sy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      rx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ry: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      rotation: {
+        type: 'number',
+        validator: commonNumberValidator
+      },
+      arc: {
+        type: 'number',
+        validator: commonNumberValidator
+      },
+      sweep: {
+        type: 'number',
+        validator: commonNumberValidator
+      },
+      ex: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ey: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      }
+    }
+  },
+  cubic: {
+    category: 'curves',
+    Component: 'Cubic',
+    command: 'cCurve',
+    args: ['cx1', 'cy1', 'cx2', 'cy2', 'ex', 'ey'],
+    description: 'Cubic is drawn...',
+    props: {
+      sx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      sy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx1: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy1: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx2: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy2: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ex: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ey: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      S: { type: 'point-array' },
+      s: { type: 'point-array' }
+    }
+  },
+  quad: {
+    category: 'curves',
+    Component: 'Quad',
+    command: 'qCurve',
+    args: ['cx', 'cy', 'ex', 'ey'],
+    description: 'Quad is drawn...',
+    props: {
+      sx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      sy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ex: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ey: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      T: { type: 'point-array' },
+      t: { type: 'point-array' }
     }
   }
 };
+
+const buildBasicShapes = () =>
+  Object.keys(docs)
+    .filter((k) => docs[k].category === 'basicShapes')
+    .reduce((accum, cur) => ({ ...accum, [cur]: docs[cur] }), {});
+
+const buildCurves = () =>
+  Object.keys(docs)
+    .filter((k) => docs[k].category === 'curves')
+    .reduce((accum, cur) => ({ ...accum, [cur]: docs[cur] }), {});
+
+export const basicShapes = buildBasicShapes();
+export const curves = buildCurves();
 
 export default docs;

--- a/src/components/BasicShapes.test.js
+++ b/src/components/BasicShapes.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import * as Shapes from '../';
-import docs from '../docs/docs';
+import docs, { basicShapes } from '../docs/docs';
 import Path from './Path';
 
 const basicShapeTest = (Component) => {
@@ -34,11 +34,10 @@ const BSP = {
 };
 
 describe('Basic Shapes', () => {
-  Object.keys(docs.basicShapes)
+  Object.keys(basicShapes)
     .filter((k) => k !== 'line')
     .forEach((k) => {
-      const doc = docs.basicShapes[k];
-
+      const doc = docs[k];
       const { args, command, props: componentProps, Component } = doc;
       const props = Object.keys(componentProps)
         .filter((c) => componentProps[c].isRequired)

--- a/src/components/Circle.js
+++ b/src/components/Circle.js
@@ -2,6 +2,8 @@ import docs from '../docs/docs';
 import createSimpleComponent from '../utils/createSimpleComponent';
 
 export const Circle = (props) => {
-  const doc = docs.basicShapes.circle;
+  const doc = docs.circle;
   return createSimpleComponent(doc, props);
 };
+
+Circle.displayName = 'Circle';

--- a/src/components/Cubic.test.js
+++ b/src/components/Cubic.test.js
@@ -19,7 +19,7 @@ const commonProps = {
   ey: 10
 };
 
-const args = docs.curves.cubic.args;
+const args = docs.cubic.args;
 
 describe('Cubic', () => {
   it(`Cubic should render correct S commands`, () => {

--- a/src/components/Curves.test.js
+++ b/src/components/Curves.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import * as Shapes from '../';
-import docs from '../docs/docs';
+import docs, { curves } from '../docs/docs';
 import Path from './Path';
 
 const shapeTest = (Component) => {
@@ -27,8 +27,8 @@ const BSP = {
 };
 
 describe('Curves', () => {
-  Object.keys(docs.curves).forEach((k) => {
-    const doc = docs.curves[k];
+  Object.keys(curves).forEach((k) => {
+    const doc = docs[k];
 
     const { args, command, props: componentProps, Component } = doc;
     const props = Object.keys(componentProps).reduce((accum, cur) => {

--- a/src/components/Ellipse.js
+++ b/src/components/Ellipse.js
@@ -2,6 +2,6 @@ import docs from '../docs/docs';
 import createSimpleComponent from '../utils/createSimpleComponent';
 
 export const Ellipse = (props) => {
-  const doc = docs.basicShapes.ellipse;
+  const doc = docs.ellipse;
   return createSimpleComponent(doc, props);
 };

--- a/src/components/Polygon.js
+++ b/src/components/Polygon.js
@@ -2,6 +2,6 @@ import docs from '../docs/docs';
 import createSimpleComponent from '../utils/createSimpleComponent';
 
 export const Polygon = (props) => {
-  const doc = docs.basicShapes.polygon;
+  const doc = docs.polygon;
   return createSimpleComponent(doc, props);
 };

--- a/src/components/Polygram.js
+++ b/src/components/Polygram.js
@@ -2,6 +2,6 @@ import docs from '../docs/docs';
 import createSimpleComponent from '../utils/createSimpleComponent';
 
 export const Polygram = (props) => {
-  const doc = docs.basicShapes.polygram;
+  const doc = docs.polygram;
   return createSimpleComponent(doc, props);
 };

--- a/src/components/Polyline.js
+++ b/src/components/Polyline.js
@@ -2,6 +2,6 @@ import docs from '../docs/docs';
 import createSimpleComponent from '../utils/createSimpleComponent';
 
 export const Polyline = (props) => {
-  const doc = docs.basicShapes.polyline;
+  const doc = docs.polyline;
   return createSimpleComponent(doc, props);
 };

--- a/src/components/Quad.test.js
+++ b/src/components/Quad.test.js
@@ -17,7 +17,7 @@ const commonProps = {
   ey: 50
 };
 
-const args = docs.curves.quad.args;
+const args = docs.quad.args;
 
 describe('Quad', () => {
   it(`Quad should render correct T commands`, () => {

--- a/src/components/RadialLines.js
+++ b/src/components/RadialLines.js
@@ -2,6 +2,6 @@ import docs from '../docs/docs';
 import createSimpleComponent from '../utils/createSimpleComponent';
 
 export const RadialLines = (props) => {
-  const doc = docs.basicShapes.radialLines;
+  const doc = docs.radialLines;
   return createSimpleComponent(doc, props);
 };

--- a/src/components/Rect.js
+++ b/src/components/Rect.js
@@ -2,6 +2,6 @@ import docs from '../docs/docs';
 import createSimpleComponent from '../utils/createSimpleComponent';
 
 export const Rect = (props) => {
-  const doc = docs.basicShapes.rect;
+  const doc = docs.rect;
   return createSimpleComponent(doc, props);
 };

--- a/src/components/RegPolygon.js
+++ b/src/components/RegPolygon.js
@@ -2,6 +2,6 @@ import docs from '../docs/docs';
 import createSimpleComponent from '../utils/createSimpleComponent';
 
 export const RegPolygon = (props) => {
-  const doc = docs.basicShapes.regPolygon;
+  const doc = docs.regPolygon;
   return createSimpleComponent(doc, props);
 };

--- a/src/components/Sector.js
+++ b/src/components/Sector.js
@@ -2,6 +2,6 @@ import docs from '../docs/docs';
 import createSimpleComponent from '../utils/createSimpleComponent';
 
 export const Sector = (props) => {
-  const doc = docs.basicShapes.sector;
+  const doc = docs.sector;
   return createSimpleComponent(doc, props);
 };

--- a/src/components/Segment.js
+++ b/src/components/Segment.js
@@ -2,6 +2,6 @@ import docs from '../docs/docs';
 import createSimpleComponent from '../utils/createSimpleComponent';
 
 export const Segment = (props) => {
-  const doc = docs.basicShapes.segment;
+  const doc = docs.segment;
   return createSimpleComponent(doc, props);
 };

--- a/src/components/Square.js
+++ b/src/components/Square.js
@@ -2,6 +2,6 @@ import docs from '../docs/docs';
 import createSimpleComponent from '../utils/createSimpleComponent';
 
 export const Square = (props) => {
-  const doc = docs.basicShapes.square;
+  const doc = docs.square;
   return createSimpleComponent(doc, props);
 };

--- a/src/components/Star.js
+++ b/src/components/Star.js
@@ -2,6 +2,6 @@ import docs from '../docs/docs';
 import createSimpleComponent from '../utils/createSimpleComponent';
 
 export const Star = (props) => {
-  const doc = docs.basicShapes.star;
+  const doc = docs.star;
   return createSimpleComponent(doc, props);
 };

--- a/src/components/Triangle.js
+++ b/src/components/Triangle.js
@@ -2,6 +2,6 @@ import docs from '../docs/docs';
 import createSimpleComponent from '../utils/createSimpleComponent';
 
 export const Triangle = (props) => {
-  const doc = docs.basicShapes.triangle;
+  const doc = docs.triangle;
   return createSimpleComponent(doc, props);
 };

--- a/src/docs/docs.js
+++ b/src/docs/docs.js
@@ -23,559 +23,585 @@ const centeredShapeNestingProps = {
 };
 
 const docs = {
-  basicShapes: {
-    circle: {
-      Component: 'Circle',
-      command: 'circle',
-      args: ['size', 'cx', 'cy'],
-      description:
-        'Circle is drawn from center points (cx & cy). The cursor is then moved to the center points.',
-      props: {
-        size: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
+  circle: {
+    category: 'basicShapes',
+    Component: 'Circle',
+    command: 'circle',
+    args: ['size', 'cx', 'cy'],
+    description:
+      'Circle is drawn from center points (cx & cy). The cursor is then moved to the center points.',
+    props: {
+      size: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       },
-      nestingProps: centeredShapeNestingProps
-    },
-    ellipse: {
-      Component: 'Ellipse',
-      command: 'ellipse',
-      args: ['width', 'height', 'cx', 'cy'],
-      description:
-        'Ellipse is drawn from center point (cx & cy). The cursor is then moved to the center point.',
-      props: {
-        width: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        height: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       },
-      nestingProps: centeredShapeNestingProps
-    },
-    polygon: {
-      Component: 'Polygon',
-      command: 'polygon',
-      args: ['points'],
-      description:
-        'Polygon accepts an array of [x, y] coordinates and then draws lines connecting those points.  The path will start from the first point and end on the first point - closing the shape.',
-      props: {
-        points: {
-          type: 'point-array',
-          isRequired: true,
-          validator: pointArrayValidator
-        }
-      },
-      nestingProps: ({ points }) => {
-        const [sx, sy] = points[0];
-        const [ex, ey] = points[points.length - 1];
-        return { ex: sx, ey: sy, sx: ex, sy: ey };
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       }
     },
-    polygram: {
-      Component: 'Polygram',
-      command: 'polygram',
-      args: ['size', 'points', 'cx', 'cy', 'vertexSkip'],
-      description:
-        'Polygram is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.  Skipping a vertex is what makes a polygram appear as intersecting lines, a vertexSkip of 1 will result in a regular polygon.',
-      props: {
-        size: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        points: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        vertexSkip: {
-          type: 'number',
-          validator: commonNumberValidator,
-          default: 2
-        }
+    nestingProps: centeredShapeNestingProps
+  },
+  ellipse: {
+    category: 'basicShapes',
+    Component: 'Ellipse',
+    command: 'ellipse',
+    args: ['width', 'height', 'cx', 'cy'],
+    description:
+      'Ellipse is drawn from center point (cx & cy). The cursor is then moved to the center point.',
+    props: {
+      width: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       },
-      nestingProps: centeredShapeNestingProps
-    },
-    polyline: {
-      Component: 'Polyline',
-      command: 'polyline',
-      args: ['points', 'relative'],
-      description:
-        'Polyline accepts an array of [x, y] coordinates and then draws lines connecting those points.  The path will start from the first point and end on the last.  points can be absolute or relative.',
-      props: {
-        points: {
-          type: 'point-array',
-          isRequired: true,
-          validator: pointArrayValidator
-        },
-        relative: { type: 'boolean' }
+      height: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       },
-      nestingProps: ({ points }) => {
-        const [sx, sy] = points[0];
-        const [ex, ey] = points[points.length - 1];
-        return { ex: sx, ey: sy, sx: ex, sy: ey };
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       }
     },
-    line: {
-      Component: 'Line',
-      command: 'lineTo',
-      args: ['x', 'y'],
-      description:
-        'Line is drawn from starting points (sx & sy) to ending points (ex & ey). sx (starting x) & sy (starting y) will always be absolutely positioned, however with relative=true the ex and ey points can relative to sx & sy.',
-      props: {
-        sx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        sy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ex: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ey: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        relative: { type: 'boolean' }
+    nestingProps: centeredShapeNestingProps
+  },
+  polygon: {
+    category: 'basicShapes',
+    Component: 'Polygon',
+    command: 'polygon',
+    args: ['points'],
+    description:
+      'Polygon accepts an array of [x, y] coordinates and then draws lines connecting those points.  The path will start from the first point and end on the first point - closing the shape.',
+    props: {
+      points: {
+        type: 'point-array',
+        isRequired: true,
+        validator: pointArrayValidator
       }
     },
-    radialLines: {
-      Component: 'RadialLines',
-      command: 'radialLines',
-      args: ['outerSize', 'innerSize', 'points', 'cx', 'cy'],
-      description:
-        'RadialLines is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.',
-      props: {
-        outerSize: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        innerSize: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        points: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
-    },
-    rect: {
-      Component: 'Rect',
-      command: 'rect',
-      args: ['width', 'height', 'cx', 'cy'],
-      description:
-        'Rect is drawn from center point (cx & cy). The cursor is then moved to the center point.',
-      props: {
-        width: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        height: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
-    },
-    regPolygon: {
-      Component: 'RegPolygon',
-      command: 'regPolygon',
-      args: ['size', 'sides', 'cx', 'cy'],
-      description:
-        'RegPolygon is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.',
-      props: {
-        size: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        sides: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
-    },
-    sector: {
-      Component: 'Sector',
-      command: 'sector',
-      args: ['cx', 'cy', 'size', 'startAngle', 'endAngle'],
-      description:
-        'Sector is drawn from center point (cx & cy). The cursor is then moved to the center point.',
-      props: {
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        size: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        startAngle: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        endAngle: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
-    },
-    segment: {
-      Component: 'Segment',
-      command: 'segment',
-      args: ['cx', 'cy', 'size', 'startAngle', 'endAngle'],
-      description:
-        'Segment is drawn from center point (cx & cy). The cursor is then moved to the center point.',
-      props: {
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        size: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        startAngle: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        endAngle: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
-    },
-    square: {
-      Component: 'Square',
-      command: 'square',
-      args: ['size', 'cx', 'cy'],
-      description:
-        'Square is drawn from center point (cx & cy). The cursor is then moved to the center point.',
-      props: {
-        size: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
-    },
-    star: {
-      Component: 'Star',
-      command: 'star',
-      args: ['outerSize', 'innerSize', 'points', 'cx', 'cy'],
-      description:
-        'Star is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.',
-      props: {
-        outerSize: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        innerSize: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        points: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
-    },
-    triangle: {
-      Component: 'Triangle',
-      command: 'triangle',
-      args: ['size', 'cx', 'cy'],
-      description:
-        'Triangle draws an equilateral triangle from center point (cx & cy). The cursor is then moved to the center point.',
-      props: {
-        size: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
-      },
-      nestingProps: centeredShapeNestingProps
+    nestingProps: ({ points }) => {
+      const [sx, sy] = points[0];
+      const [ex, ey] = points[points.length - 1];
+      return { ex: sx, ey: sy, sx: ex, sy: ey };
     }
   },
-  curves: {
-    arc: {
-      Component: 'Arc',
-      command: 'arc',
-      args: ['rx', 'ry', 'rotation', 'arc', 'sweep', 'ex', 'ey'],
-      description: 'Arc is drawn...',
-      props: {
-        sx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        sy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        rx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ry: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        rotation: {
-          type: 'number',
-          validator: commonNumberValidator
-        },
-        arc: {
-          type: 'number',
-          validator: commonNumberValidator
-        },
-        sweep: {
-          type: 'number',
-          validator: commonNumberValidator
-        },
-        ex: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ey: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        }
+  polygram: {
+    category: 'basicShapes',
+    Component: 'Polygram',
+    command: 'polygram',
+    args: ['size', 'points', 'cx', 'cy', 'vertexSkip'],
+    description:
+      'Polygram is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.  Skipping a vertex is what makes a polygram appear as intersecting lines, a vertexSkip of 1 will result in a regular polygon.',
+    props: {
+      size: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      points: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      vertexSkip: {
+        type: 'number',
+        validator: commonNumberValidator,
+        default: 2
       }
     },
-    cubic: {
-      Component: 'Cubic',
-      command: 'cCurve',
-      args: ['cx1', 'cy1', 'cx2', 'cy2', 'ex', 'ey'],
-      description: 'Cubic is drawn...',
-      props: {
-        sx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        sy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx1: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy1: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx2: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy2: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ex: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ey: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        S: { type: 'point-array' },
-        s: { type: 'point-array' }
+    nestingProps: centeredShapeNestingProps
+  },
+  polyline: {
+    category: 'basicShapes',
+    Component: 'Polyline',
+    command: 'polyline',
+    args: ['points', 'relative'],
+    description:
+      'Polyline accepts an array of [x, y] coordinates and then draws lines connecting those points.  The path will start from the first point and end on the last.  points can be absolute or relative.',
+    props: {
+      points: {
+        type: 'point-array',
+        isRequired: true,
+        validator: pointArrayValidator
+      },
+      relative: { type: 'boolean' }
+    },
+    nestingProps: ({ points }) => {
+      const [sx, sy] = points[0];
+      const [ex, ey] = points[points.length - 1];
+      return { ex: sx, ey: sy, sx: ex, sy: ey };
+    }
+  },
+  line: {
+    category: 'basicShapes',
+    Component: 'Line',
+    command: 'lineTo',
+    args: ['x', 'y'],
+    description:
+      'Line is drawn from starting points (sx & sy) to ending points (ex & ey). sx (starting x) & sy (starting y) will always be absolutely positioned, however with relative=true the ex and ey points can relative to sx & sy.',
+    props: {
+      sx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      sy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ex: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ey: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      relative: { type: 'boolean' }
+    }
+  },
+  radialLines: {
+    category: 'basicShapes',
+    Component: 'RadialLines',
+    command: 'radialLines',
+    args: ['outerSize', 'innerSize', 'points', 'cx', 'cy'],
+    description:
+      'RadialLines is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.',
+    props: {
+      outerSize: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      innerSize: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      points: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       }
     },
-    quad: {
-      Component: 'Quad',
-      command: 'qCurve',
-      args: ['cx', 'cy', 'ex', 'ey'],
-      description: 'Quad is drawn...',
-      props: {
-        sx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        sy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cx: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        cy: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ex: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        ey: {
-          type: 'number',
-          isRequired: true,
-          validator: commonNumberValidator
-        },
-        T: { type: 'point-array' },
-        t: { type: 'point-array' }
+    nestingProps: centeredShapeNestingProps
+  },
+  rect: {
+    category: 'basicShapes',
+    Component: 'Rect',
+    command: 'rect',
+    args: ['width', 'height', 'cx', 'cy'],
+    description:
+      'Rect is drawn from center point (cx & cy). The cursor is then moved to the center point.',
+    props: {
+      width: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      height: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
       }
+    },
+    nestingProps: centeredShapeNestingProps
+  },
+  regPolygon: {
+    category: 'basicShapes',
+    Component: 'RegPolygon',
+    command: 'regPolygon',
+    args: ['size', 'sides', 'cx', 'cy'],
+    description:
+      'RegPolygon is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.',
+    props: {
+      size: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      sides: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      }
+    },
+    nestingProps: centeredShapeNestingProps
+  },
+  sector: {
+    category: 'basicShapes',
+    Component: 'Sector',
+    command: 'sector',
+    args: ['cx', 'cy', 'size', 'startAngle', 'endAngle'],
+    description:
+      'Sector is drawn from center point (cx & cy). The cursor is then moved to the center point.',
+    props: {
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      size: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      startAngle: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      endAngle: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      }
+    },
+    nestingProps: centeredShapeNestingProps
+  },
+  segment: {
+    category: 'basicShapes',
+    Component: 'Segment',
+    command: 'segment',
+    args: ['cx', 'cy', 'size', 'startAngle', 'endAngle'],
+    description:
+      'Segment is drawn from center point (cx & cy). The cursor is then moved to the center point.',
+    props: {
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      size: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      startAngle: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      endAngle: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      }
+    },
+    nestingProps: centeredShapeNestingProps
+  },
+  square: {
+    category: 'basicShapes',
+    Component: 'Square',
+    command: 'square',
+    args: ['size', 'cx', 'cy'],
+    description:
+      'Square is drawn from center point (cx & cy). The cursor is then moved to the center point.',
+    props: {
+      size: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      }
+    },
+    nestingProps: centeredShapeNestingProps
+  },
+  star: {
+    category: 'basicShapes',
+    Component: 'Star',
+    command: 'star',
+    args: ['outerSize', 'innerSize', 'points', 'cx', 'cy'],
+    description:
+      'Star is drawn from center point (cx & cy). The first outer point of the shape will always be at top center. The cursor is then moved to the center point.',
+    props: {
+      outerSize: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      innerSize: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      points: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      }
+    },
+    nestingProps: centeredShapeNestingProps
+  },
+  triangle: {
+    category: 'basicShapes',
+    Component: 'Triangle',
+    command: 'triangle',
+    args: ['size', 'cx', 'cy'],
+    description:
+      'Triangle draws an equilateral triangle from center point (cx & cy). The cursor is then moved to the center point.',
+    props: {
+      size: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      }
+    },
+    nestingProps: centeredShapeNestingProps
+  },
+  arc: {
+    category: 'curves',
+    Component: 'Arc',
+    command: 'arc',
+    args: ['rx', 'ry', 'rotation', 'arc', 'sweep', 'ex', 'ey'],
+    description: 'Arc is drawn...',
+    props: {
+      sx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      sy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      rx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ry: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      rotation: {
+        type: 'number',
+        validator: commonNumberValidator
+      },
+      arc: {
+        type: 'number',
+        validator: commonNumberValidator
+      },
+      sweep: {
+        type: 'number',
+        validator: commonNumberValidator
+      },
+      ex: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ey: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      }
+    }
+  },
+  cubic: {
+    category: 'curves',
+    Component: 'Cubic',
+    command: 'cCurve',
+    args: ['cx1', 'cy1', 'cx2', 'cy2', 'ex', 'ey'],
+    description: 'Cubic is drawn...',
+    props: {
+      sx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      sy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx1: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy1: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx2: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy2: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ex: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ey: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      S: { type: 'point-array' },
+      s: { type: 'point-array' }
+    }
+  },
+  quad: {
+    category: 'curves',
+    Component: 'Quad',
+    command: 'qCurve',
+    args: ['cx', 'cy', 'ex', 'ey'],
+    description: 'Quad is drawn...',
+    props: {
+      sx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      sy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cx: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      cy: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ex: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      ey: {
+        type: 'number',
+        isRequired: true,
+        validator: commonNumberValidator
+      },
+      T: { type: 'point-array' },
+      t: { type: 'point-array' }
     }
   }
 };
+
+const buildBasicShapes = () =>
+  Object.keys(docs)
+    .filter((k) => docs[k].category === 'basicShapes')
+    .reduce((accum, cur) => ({ ...accum, [cur]: docs[cur] }), {});
+
+const buildCurves = () =>
+  Object.keys(docs)
+    .filter((k) => docs[k].category === 'curves')
+    .reduce((accum, cur) => ({ ...accum, [cur]: docs[cur] }), {});
+
+export const basicShapes = buildBasicShapes();
+export const curves = buildCurves();
 
 export default docs;


### PR DESCRIPTION
flattening these docs will be helpful for a few reasons.  
* No longer need to know where to look for the "category", it is now a part of the component definition
* basicShapes & curves is now exported as a simple filter using the in-definition value - so very few code changes
* this will enable easier exploration of Shape or curve as a prop for things like animateMotion, `<Circle motion={<Arc />} />` here we don't need to determine is Arc is a `basicShape` or `curve` - it defines itself in the docs and we can respond accordingly
* This has no impact on users - docs.js is purely internal.