### PR TITLE
docs(marker demo): use clone of curve demo data

### DIFF
--- a/example/src/components/demo-builders/CurveDemo.js
+++ b/example/src/components/demo-builders/CurveDemo.js
@@ -9,7 +9,7 @@ import { translate as t } from '../../i18n/i18n';
 
 export const CurveDemo = ({ curve }) => {
   const { Component, props } = docs[curve];
-  const demos = demoDocs.curves[curve];
+  const demos = JSON.parse(JSON.stringify(demoDocs.curves[curve]));
   const initialState = demos.map((d, i) => {
     return Object.keys(d)
       .filter((k) => k !== 'svgDimensions')


### PR DESCRIPTION
MarkerDemo was being impacted by changes to the Quad demo because they were both using the safe
referenced data set.  This fixes that.