### PR TITLE
refactor(docs): improve inline documentation of createSimpleComponent.js

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -16730,7 +16730,7 @@
     "react-svg-path": {
       "version": "file:..",
       "requires": {
-        "@joemaddalone/path": "1.0.7"
+        "@joemaddalone/path": "^1.1.0"
       },
       "dependencies": {
         "@joemaddalone/path": {

--- a/src/utils/cleanAttributes.js
+++ b/src/utils/cleanAttributes.js
@@ -1,6 +1,16 @@
-const cleanAttributes = (attributes) => {
+const cleanAttributes = (attributes, additionalRemoves = []) => {
   const allowedAttributes = { ...attributes };
-  const removeAttributes = ['sx', 'sy', 'cx', 'cy', 'oy', 'ox', 'ex', 'ey'];
+  const removeAttributes = [
+    'sx',
+    'sy',
+    'cx',
+    'cy',
+    'oy',
+    'ox',
+    'ex',
+    'ey',
+    ...additionalRemoves
+  ];
   removeAttributes.forEach((attr) => delete allowedAttributes[attr]);
   return allowedAttributes;
 };

--- a/src/utils/validateProps.js
+++ b/src/utils/validateProps.js
@@ -1,0 +1,38 @@
+const validateProps = (props, componentDoc, componentProps) => {
+  const augment = {};
+  const msg = [];
+  const result = Object.keys(componentProps).every((k) => {
+    // eslint-disable-next-line no-prototype-builtins
+    const hasProp = props.hasOwnProperty(k);
+    if (!componentProps[k].isRequired && !hasProp) {
+      if (componentProps[k].type !== 'boolean') {
+        augment[k] =
+          componentDoc.props[k].default !== undefined
+            ? componentProps[k].default
+            : null;
+      }
+      return true;
+    }
+    if (hasProp && componentProps[k].type === 'boolean') {
+      return props[k] === true || props[k] === false;
+    }
+    if (componentProps[k].isRequired && !hasProp) {
+      // eslint-disable-next-line no-prototype-builtins
+      if (componentProps[k].hasOwnProperty('default')) {
+        augment[k] = componentDoc.props[k].default;
+        return true;
+      } else {
+        msg.push(`Required ${k} prop is missing in ${componentDoc.Component}.`);
+        return false;
+      }
+    }
+    const valid = componentProps[k].validator(props[k]);
+    if (!valid) {
+      msg.push(`${k} prop is invalid in ${componentDoc.Component}.`);
+    }
+    return hasProp && valid;
+  });
+  return { result, augment, msg };
+};
+
+export default validateProps;


### PR DESCRIPTION
moves validateProps into its own file, some more informative variable naming, inline comments in
createSimpleComponent.js